### PR TITLE
Fix: Обновить CSP в next.config.ts для Vercel

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -56,7 +56,7 @@ const nextConfig = {
               "font-src 'self' data: https://fonts.gstatic.com",
 
               // Подключения
-              "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://mc.yandex.ru",
+              "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://mc.yandex.ru https://www.google-analytics.com",
 
               // Фреймы
               "frame-src 'self' https://yandex.ru",


### PR DESCRIPTION
Content Security Policy блокировал запросы к Яндекс Метрике и Google Analytics из-за отсутствия этих доменов в директиве `connect-src`.

Это изменение обновляет директиву `connect-src` в файле `next.config.ts`, чтобы включить `https://mc.yandex.ru` и `https://www.google-analytics.com`, исправляя ошибки CSP при загрузке этих скриптов на Vercel.